### PR TITLE
Add math header for M_PI

### DIFF
--- a/QtQuickApplication/model/vrdatainterfacer3e.h
+++ b/QtQuickApplication/model/vrdatainterfacer3e.h
@@ -1,6 +1,7 @@
 #ifndef R3E_DATAINTERFACE_H
 #define R3E_DATAINTERFACE_H
 
+#include <math.h>
 #include "r3e.h"
 #include "vrdatainterface.h"
 

--- a/QtQuickApplication/qcustomplot.h
+++ b/QtQuickApplication/qcustomplot.h
@@ -26,6 +26,7 @@
 #ifndef QCUSTOMPLOT_H
 #define QCUSTOMPLOT_H
 
+#include <math.h>
 #include <QtCore/qglobal.h>
 
 // some Qt version/configuration dependent macros to include or exclude certain code paths:


### PR DESCRIPTION
 - M_PI is declared in math.h for most compilers
 - M_PI is not defined in the C++ standard